### PR TITLE
Specify which attribute is missing on which Entity

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 292
+  Max: 296
 
 # Offense count: 4
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Next Release
 * Your contribution here.
 * [#98](https://github.com/intridea/grape-entity/pull/98): Add nested conditionals - [@zbelzer](https://github.com/zbelzer).
 * [#91](https://github.com/intridea/grape-entity/pull/91): Fix OpenStruct serializing - [@etehtsea](https://github.com/etehtsea).
+* [#105](https://github.com/intridea/grape-entity/pull/105): Specify which attribute is missing in which Entity - [@jhollinger](https://github.com/jhollinger).
 
 0.4.4 (2014-08-17)
 ==================

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -558,7 +558,11 @@ module Grape
         elsif object.respond_to?(:fetch, true)
           object.fetch(name)
         else
-          object.send(name)
+          begin
+            object.send(name)
+          rescue NoMethodError
+            raise NoMethodError, "#{self.class.name} missing attribute `#{name}' on #{object}"
+          end
         end
       end
     end

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -462,7 +462,7 @@ describe Grape::Entity do
         subject.expose(:awesome)
         expect do
           subject.represent(Object.new, serializable: true)
-        end.to raise_error(NoMethodError)
+        end.to raise_error(NoMethodError, /missing attribute `awesome'/)
       end
     end
 


### PR DESCRIPTION
In the latest release, the `ArgumentError` resulting when an Entity exposes a non-existing attribute (due to typos, merges, pending database migrations, etc.) gives no context as to which attribute is missing, or even which Entity is to blame (including in the backtrace). In master I notice it now gives a `NoMethodError`. That's arguably an improvement, but it also tends to even further obscure that grape-entity has anything to do with the error.

In short, finding the Entity and attribute responsible for these errors is often difficult and tedious, especially in large codebases. I think a simple change to the exception message will make them much easier to find and fix.  Something along the lines of `NoMethodError: Entities::V1::Session missing attribute 'foo' on #<User:0x007f787ed1c7b8>`.

**Message in 0.4.4**

    ArgumentError: ArgumentError
        /home/jhollinger/.gem/ruby/2.1.0/gems/grape-entity-0.4.4/lib/grape_entity/entity.rb:557:in `delegate_attribute'
        ...

**Message in master**

    NoMethodError: undefined method `foo' for #<User:0x007f9b0d22b2a8>
        /home/jhollinger/.gem/ruby/2.1.0/gems/activemodel-4.1.8/lib/active_model/attribute_methods.rb:435:in `method_missing'
        ....

**Example proposed message**

    NoMethodError: Entities::V1::Session missing attribute `foo' on #<User:0x007f787ed1c7b8>
        /home/jhollinger/.gem/ruby/2.1.0/gems/grape-entity-0.4.4/lib/grape_entity/entity.rb:560:in `rescue in delegate_attribute'
        ...