### PR TITLE
Add Unexpose Method

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 296
+  Max: 300
 
 # Offense count: 4
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Next Release
 ============
 
 * Your contribution here.
+* [#109](https://github.com/intridea/grape-entity/pull/109): Add unexpose method - [@jonmchan](https://github.com/jonmchan).
 * [#98](https://github.com/intridea/grape-entity/pull/98): Add nested conditionals - [@zbelzer](https://github.com/zbelzer).
 * [#91](https://github.com/intridea/grape-entity/pull/91): Fix OpenStruct serializing - [@etehtsea](https://github.com/etehtsea).
 * [#105](https://github.com/intridea/grape-entity/pull/105): Specify which attribute is missing in which Entity - [@jhollinger](https://github.com/jhollinger).

--- a/README.md
+++ b/README.md
@@ -199,6 +199,31 @@ private
 end
 ```
 
+#### Unexpose
+
+To undefine an exposed field, use the ```.unexpose``` method. Useful for modifying inherited entities.
+
+```ruby
+class UserData < Grape::Entity
+  expose :name
+  expose :address1
+  expose :address2
+  expose :address_state
+  expose :address_city
+  expose :email
+  expose :phone
+end
+
+class MailingAddress < UserData
+  unexpose :email
+  unexpose :phone
+end
+```
+
+
+
+
+
 #### Aliases
 
 Expose under a different name with `:as`.

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -158,6 +158,10 @@ module Grape
       end
     end
 
+    def self.unexpose(attribute)
+      exposures.delete(attribute)
+    end
+
     # Set options that will be applied to any exposures declared inside the block.
     #
     # @example Multi-exposure if


### PR DESCRIPTION
Add a method to unexpose an attribute. 

**Scenario for use:**

You wish to inherit from a Grape::Entity that has more parameters exposed than the child entity should have exposed, you can simply inherit from the parent and unexpose the parameters that you don't want exposed.


Example:
```ruby
class UserData < Grape::Entity
  expose :name
  expose :address1
  expose :address2
  expose :address_state
  expose :address_city
  expose :email
  expose :phone
end

class MailingAddress < UserData
  unexpose :email
  unexpose :phone
end
```


