### PR TITLE
Fixed exposure of attributes marked as safe when using hash models.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Next Release
 ============
 
 * Your contribution here.
+* [#110](https://github.com/intridea/grape-entity/pull/110): Fixed safe exposure when using `Hash` models - [@croeck](https://github.com/croeck).
 * [#109](https://github.com/intridea/grape-entity/pull/109): Add unexpose method - [@jonmchan](https://github.com/jonmchan).
 * [#98](https://github.com/intridea/grape-entity/pull/98): Add nested conditionals - [@zbelzer](https://github.com/zbelzer).
 * [#91](https://github.com/intridea/grape-entity/pull/91): Fix OpenStruct serializing - [@etehtsea](https://github.com/etehtsea).

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -576,7 +576,8 @@ module Grape
       (nested_exposures.any? && nested_exposures.all? { |a, o| valid_exposure?(a, o) }) || \
         exposure_options.key?(:proc) || \
         !exposure_options[:safe] || \
-        object.respond_to?(self.class.name_for(attribute))
+        object.respond_to?(self.class.name_for(attribute)) || \
+        object.is_a?(Hash) && object.key?(self.class.name_for(attribute))
     end
 
     def conditions_met?(exposure_options, options)

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -683,6 +683,13 @@ describe Grape::Entity do
           expect(res).to have_key :name
         end
 
+        it 'does expose attributes marked as safe if model is a hash object' do
+          fresh_class.expose :name, safe: true
+
+          res = fresh_class.new(name: 'myname').serializable_hash
+          expect(res).to have_key :name
+        end
+
         it "does not expose attributes that don't exist on the object, even with criteria" do
           fresh_class.expose :email
           fresh_class.expose :nonexistent_attribute, safe: true, if: lambda { false }


### PR DESCRIPTION
The valid_exposure check now also accepts Hash objects that have a key matching the attribute's name.
Fix includes `spec` that demonstrates the issue and fails without the changes.