### PR TITLE
Fix: allow usage of attributes with name 'key' if `Hash` objects are used

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 300
+  Max: 301
 
 # Offense count: 4
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Next Release
 ============
 
 * Your contribution here.
+* [#111](https://github.com/intridea/grape-entity/pull/111): Fix: allow usage of attributes with name 'key' if `Hash` objects are used - [@croeck](https://github.com/croeck).
 * [#110](https://github.com/intridea/grape-entity/pull/110): Fixed safe exposure when using `Hash` models - [@croeck](https://github.com/croeck).
 * [#109](https://github.com/intridea/grape-entity/pull/109): Add unexpose method - [@jonmchan](https://github.com/jonmchan).
 * [#98](https://github.com/intridea/grape-entity/pull/98): Add nested conditionals - [@zbelzer](https://github.com/zbelzer).

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -556,17 +556,17 @@ module Grape
       name = self.class.name_for(attribute)
       if respond_to?(name, true)
         send(name)
+      elsif object.is_a?(Hash)
+        object[name]
+      elsif object.respond_to?(name, true)
+        object.send(name)
+      elsif object.respond_to?(:fetch, true)
+        object.fetch(name)
       else
-        if object.respond_to?(name, true)
+        begin
           object.send(name)
-        elsif object.respond_to?(:fetch, true)
-          object.fetch(name)
-        else
-          begin
-            object.send(name)
-          rescue NoMethodError
-            raise NoMethodError, "#{self.class.name} missing attribute `#{name}' on #{object}"
-          end
+        rescue NoMethodError
+          raise NoMethodError, "#{self.class.name} missing attribute `#{name}' on #{object}"
         end
       end
     end

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -649,9 +649,12 @@ describe Grape::Entity do
         email: 'bob@example.com',
         birthday: Time.gm(2012, 2, 27),
         fantasies: ['Unicorns', 'Double Rainbows', 'Nessy'],
+        characteristics: [
+          { key: 'hair_color', value: 'brown' }
+        ],
         friends: [
-          double(name: 'Friend 1', email: 'friend1@example.com', fantasies: [], birthday: Time.gm(2012, 2, 27), friends: []),
-          double(name: 'Friend 2', email: 'friend2@example.com', fantasies: [], birthday: Time.gm(2012, 2, 27), friends: [])
+          double(name: 'Friend 1', email: 'friend1@example.com', characteristics: [], fantasies: [], birthday: Time.gm(2012, 2, 27), friends: []),
+          double(name: 'Friend 2', email: 'friend2@example.com', characteristics: [], fantasies: [], birthday: Time.gm(2012, 2, 27), friends: [])
         ]
       }
     end
@@ -911,6 +914,25 @@ describe Grape::Entity do
           rep = subject.send(:value_for, :first_friend)
           expect(rep).to be_kind_of EntitySpec::FriendEntity
           expect(rep.serializable_hash).to be_nil
+        end
+
+        it 'passes through exposed entity with key and value attributes' do
+          module EntitySpec
+            class CharacteristicsEntity < Grape::Entity
+              root 'characteristics', 'characteristic'
+              expose :key, :value
+            end
+          end
+
+          fresh_class.class_eval do
+            expose :characteristics, using: EntitySpec::CharacteristicsEntity
+          end
+
+          rep = subject.send(:value_for, :characteristics)
+          expect(rep).to be_kind_of Array
+          expect(rep.reject { |r| r.is_a?(EntitySpec::CharacteristicsEntity) }).to be_empty
+          expect(rep.first.serializable_hash[:key]).to eq 'hair_color'
+          expect(rep.first.serializable_hash[:value]).to eq 'brown'
         end
 
         it 'passes through custom options' do


### PR DESCRIPTION
Fix now is checking the method arity in the `delegate_attribute` method. With this change the key attribute will be fetched and instead of the `key` method (with arity 1) being invoked.
The fix includes a `spec` that demonstrates the issue and fails without the changes.