### PR TITLE
tracking attribute path when evaluating value

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -7,12 +7,12 @@
 
 # Offense count: 5
 Metrics/AbcSize:
-  Max: 53
+  Max: 59
 
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 301
+  Max: 304
 
 # Offense count: 4
 Metrics/CyclomaticComplexity:
@@ -26,11 +26,11 @@ Metrics/LineLength:
 # Offense count: 6
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 34
+  Max: 38
 
 # Offense count: 4
 Metrics/PerceivedComplexity:
-  Max: 15
+  Max: 16
 
 # Offense count: 2
 # Cop supports --auto-correct.

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -508,8 +508,9 @@ module Grape
 
     def value_for(attribute, options = {})
       exposure_options = exposures[attribute.to_sym]
-
       nested_exposures = self.class.nested_exposures_for(attribute)
+      orig_path = options[:attr_path]
+      options[:attr_path] = "#{orig_path}/#{self.class.key_for attribute}"
 
       if exposure_options[:using]
         exposure_options[:using] = exposure_options[:using].constantize if exposure_options[:using].respond_to? :constantize
@@ -550,6 +551,9 @@ module Grape
       else
         delegate_attribute(attribute)
       end
+
+    ensure
+      options[:attr_path] = orig_path if defined? orig_path
     end
 
     def delegate_attribute(attribute)


### PR DESCRIPTION
Tracks attribute's full nesting path, puts it into `options[:attr_path]`. With this full path, within each `expose`, user can easily detect current attribute's alias (`:as`) and full path, will be useful for such as show or hide an attribute via api params.