### PR TITLE
Root node inheritance

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 323
+  Max: 330
 
 # Offense count: 5
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ============
 
 * [#114](https://github.com/intridea/grape-entity/pull/114): Added 'only' option that selects which attributes should be returned - [@estevaoam](https://github.com/estevaoam).
+* [#115](https://github.com/intridea/grape-entity/pull/115): Allowing 'root' to be inherited from parent to child entities - [@guidoprincess](https://github.com/guidoprincess).
 * Your contribution here.
 
 0.4.5 (2015-03-10)

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -407,17 +407,27 @@ module Grape
     # @option options :only [Array] all the fields that should be returned
     def self.represent(objects, options = {})
       if objects.respond_to?(:to_ary) && ! @present_collection
-        root_element =  @collection_root
+        root_element =  root_element(:collection_root)
         inner = objects.to_ary.map { |object| new(object, { collection: true }.merge(options)).presented }
       else
         objects = { @collection_name => objects } if @present_collection
-        root_element =  @root
+        root_element = root_element(:root)
         inner = new(objects, options).presented
       end
 
       root_element = options[:root] if options.key?(:root)
 
       root_element ? { root_element => inner } : inner
+    end
+
+    # This method returns the entity's root or collection root node, or its parent's
+    # @param root_type: either :collection_root or just :root
+    def self.root_element(root_type)
+      if instance_variable_get("@#{root_type}")
+        instance_variable_get("@#{root_type}")
+      elsif superclass.respond_to? :root_element
+        superclass.root_element(root_type)
+      end
     end
 
     def presented

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -664,6 +664,30 @@ describe Grape::Entity do
           end
         end
       end
+
+      context 'inheriting from parent entity' do
+        before(:each) do
+          subject.root 'things', 'thing'
+        end
+
+        it 'inherits single root' do
+          child_class = Class.new(subject)
+          representation = child_class.represent(Object.new)
+          expect(representation).to be_kind_of Hash
+          expect(representation).to have_key 'thing'
+          expect(representation['thing']).to be_kind_of(child_class)
+        end
+
+        it 'inherits array root root' do
+          child_class = Class.new(subject)
+          representation = child_class.represent(4.times.map { Object.new })
+          expect(representation).to be_kind_of Hash
+          expect(representation).to have_key('things')
+          expect(representation['things']).to be_kind_of Array
+          expect(representation['things'].size).to eq 4
+          expect(representation['things'].reject { |r| r.is_a?(child_class) }).to be_empty
+        end
+      end
     end
 
     describe '#initialize' do


### PR DESCRIPTION
Currently, exposure is inherited from parent entities to child entities.  So, something like this works:

```
module Foo
  module Entities
    class GenericEntity < Grape::Entity
      expose :id
    end
  end
end

module Foo
  module Entities
    class SpecificEntity < GenericEntity
      #has :id already exposed
    end
  end
end
```

However, "root" is not inherited, so the following does not work

```
module Foo
  module Entities
    class GenericEntity < Grape::Entity
      root :data, :object
    end
  end
end

module Foo
  module Entities
    class SpecificEntity < GenericEntity
      #has no knowledge of parent's root settings
    end
  end
end
```

This pull request addresses the above, which is useful for those of us who want to have one standard root node name throughout the application and don't want to define it in every entity.  