### PR TITLE
Subclass documentation #121

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * [#114](https://github.com/intridea/grape-entity/pull/114): Added 'only' option that selects which attributes should be returned - [@estevaoam](https://github.com/estevaoam).
 * [#115](https://github.com/intridea/grape-entity/pull/115): Allowing 'root' to be inherited from parent to child entities - [@guidoprincess](https://github.com/guidoprincess).
+* [#121](https://github.com/intridea/grape-entity/pull/122): Sublcassed Entity#documentation properly handles unexposed params - [@dan-corneanu](https://github.com/dan-corneanu).
 * Your contribution here.
 
 0.4.5 (2015-03-10)

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -240,10 +240,6 @@ module Grape
         memo
       end
 
-      if superclass.respond_to? :documentation
-        @documentation = superclass.documentation.merge(@documentation)
-      end
-
       @documentation
     end
 

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -1149,6 +1149,46 @@ describe Grape::Entity do
 
         expect(subject.documentation).to eq(label: doc, email: doc)
       end
+
+      context 'inherited documentation' do
+        it 'returns documentation from ancestor' do
+          doc = { type: 'foo', desc: 'bar' }
+          fresh_class.expose :name, documentation: doc
+          child_class = Class.new(fresh_class)
+          child_class.expose :email, documentation: doc
+
+          expect(fresh_class.documentation).to eq(name: doc)
+          expect(child_class.documentation).to eq(name: doc, email: doc)
+        end
+
+        it 'obeys unexposed attributes in subclass' do
+          doc = { type: 'foo', desc: 'bar' }
+          fresh_class.expose :name, documentation: doc
+          fresh_class.expose :email, documentation: doc
+          child_class = Class.new(fresh_class)
+          child_class.unexpose :email
+
+          expect(fresh_class.documentation).to eq(name: doc, email: doc)
+          expect(child_class.documentation).to eq(name: doc)
+        end
+
+        it 'obeys re-exposed attributes in subclass' do
+          doc = { type: 'foo', desc: 'bar' }
+          fresh_class.expose :name, documentation: doc
+          fresh_class.expose :email, documentation: doc
+
+          child_class = Class.new(fresh_class)
+          child_class.unexpose :email
+
+          nephew_class = Class.new(child_class)
+          new_doc = { type: 'todler', descr: '???' }
+          nephew_class.expose :email, documentation: new_doc
+
+          expect(fresh_class.documentation).to eq(name: doc, email: doc)
+          expect(child_class.documentation).to eq(name: doc)
+          expect(nephew_class.documentation).to eq(name: doc, email: new_doc)
+        end
+      end
     end
 
     describe '#key_for' do


### PR DESCRIPTION
This is a proposed fix for issue
Subclasses keep the parent's .documentation? #121

Currently each Entity keeps track of its own exposures in a class object instance variable. A new entity class makes a copy of it's parent exposures then goes on and modifies its own exposures (add or remove exposures).

For the moment, I think we can fix the documentation issue by simply removing the call to **superclass.documentation**.

In the future we might have to replace the class object instance variable (which is a simple hash at the moment) with something more elaborate (like a chained filter or something) to handle the child - parent relationship better. Ex. what happens if we add some more exposures to the parent entity after we defined the child entity? I think that the child entity will not catch that extra exposure. 

Please review this pull request and let me know what you think.