### PR TITLE
Allow for strings in 'only' and 'except' options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#121](https://github.com/intridea/grape-entity/pull/122): Sublcassed Entity#documentation properly handles unexposed params - [@dan-corneanu](https://github.com/dan-corneanu).
 * [#134](https://github.com/intridea/grape-entity/pull/134): Subclasses no longer affected in all cases by `unexpose` in parent - [@etehtsea](https://github.com/etehtsea).
 * [#135](https://github.com/intridea/grape-entity/pull/135): Added `except` option - [@dan-corneanu](https://github.com/dan-corneanu).
+* [#136](https://github.com/intridea/grape-entity/pull/136): Allow for strings in `only` and `except` options - [@bswinnerton](https://github.com/bswinnerton).
 * Your contribution here.
 
 0.4.5 (2015-03-10)

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -465,7 +465,7 @@ module Grape
         else
           allowed_fields[attribute] = true
         end
-      end
+      end.symbolize_keys
 
       if for_attribute && @only_fields[for_attribute].is_a?(Array)
         @only_fields[for_attribute]
@@ -486,7 +486,7 @@ module Grape
         else
           allowed_fields[attribute] = true
         end
-      end
+      end.symbolize_keys
 
       if for_attribute && @except_fields[for_attribute].is_a?(Array)
         @except_fields[for_attribute]

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -517,6 +517,48 @@ describe Grape::Entity do
           expect(representation).to eq(name: nil)
         end
 
+        context 'with strings or symbols passed to only and except' do
+          let(:object) { OpenStruct.new(user: {}) }
+
+          before do
+            user_entity = Class.new(Grape::Entity)
+            user_entity.expose(:id, :name, :email)
+
+            subject.expose(:id, :name, :phone, :address)
+            subject.expose(:user, using: user_entity)
+          end
+
+          it 'can specify "only" option attributes as strings' do
+            representation = subject.represent(object, only: ['id', 'name', { 'user' => ['email'] }], serializable: true)
+            expect(representation).to eq(id: nil, name: nil, user: { email: nil })
+          end
+
+          it 'can specify "except" option attributes as strings' do
+            representation = subject.represent(object, except: ['id', 'name', { 'user' => ['email'] }], serializable: true)
+            expect(representation).to eq(phone: nil, address: nil, user: { id: nil, name: nil })
+          end
+
+          it 'can specify "only" option attributes as symbols' do
+            representation = subject.represent(object, only: [:name, :phone, { user: [:name] }], serializable: true)
+            expect(representation).to eq(name: nil, phone: nil, user: { name: nil })
+          end
+
+          it 'can specify "except" option attributes as symbols' do
+            representation = subject.represent(object, except: [:name, :phone, { user: [:name] }], serializable: true)
+            expect(representation).to eq(id: nil, address: nil, user: { id: nil, email: nil })
+          end
+
+          it 'can specify "only" attributes as strings and symbols' do
+            representation = subject.represent(object, only: [:id, 'address', { user: [:id, 'name'] }], serializable: true)
+            expect(representation).to eq(id: nil, address: nil, user: { id: nil, name: nil })
+          end
+
+          it 'can specify "except" attributes as strings and symbols' do
+            representation = subject.represent(object, except: [:id, 'address', { user: [:id, 'name'] }], serializable: true)
+            expect(representation).to eq(name: nil, phone: nil, user: { email: nil })
+          end
+        end
+
         it 'can specify children attributes with only' do
           user_entity = Class.new(Grape::Entity)
           user_entity.expose(:id, :name, :email)


### PR DESCRIPTION
With the addition of the `only` and `except` options, possibilities such as the [partial response](http://bit.ly/1fxWuXJ) design pattern (where the consumer of the API can specifically request only the fields that it desires) become available. A common pattern to request these fields would be via `params`, which will arrive as strings. Currently only an array of symbols (or hash containing symbols) is supported to define the desired fields.

As discussed [here](https://github.com/intridea/grape-entity/pull/114#issuecomment-79122967), it certainly should be the responsibility of another gem to do parameter validation in a partial response scenario, but such a gem would also have to do a [perhaps unnecessary] recursive symbol coercion as well when it could be handled by grape-entity, as proposed by this pull request.

This commit updates Grape::Entity to support an array of symbols _or_ strings to be passed as the `only` or `except` options of `represent`.