### PR TITLE
tracking attribute path into options[:attr_path]

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -7,12 +7,12 @@
 
 # Offense count: 8
 Metrics/AbcSize:
-  Max: 51
+  Max: 53
 
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 328
+  Max: 346
 
 # Offense count: 5
 Metrics/CyclomaticComplexity:
@@ -26,7 +26,7 @@ Metrics/LineLength:
 # Offense count: 7
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 32
+  Max: 37
 
 # Offense count: 5
 Metrics/PerceivedComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 0.5.0 (Next)
 ============
+* [#139](https://github.com/intridea/grape-entity/pull/139): Keep a track of attribute nesting path during condition check or runtime exposure - [@calfzhou](https://github.com/calfzhou).
 * Your contribution here.
 
 0.4.6 (2015-07-27)
@@ -83,4 +84,3 @@
 ==================
 
 * Initial public release - [@agileanimal](https://github.com/agileanimal).
-

--- a/README.md
+++ b/README.md
@@ -334,6 +334,32 @@ end
 ```
 **Notice**: In the above code, you should pay attention to [**Safe Exposure**](#safe-exposure) yourself, for example, `instance.address` might be `nil`, in this situation, it is better to expose it as nil directly.
 
+#### Attribute Path Tracking
+
+Sometimes, especially when there are nested attributes, you might want to know which attribute it
+is being exposed. For example, some APIs allow user provide a parameter to control which fields
+will be included in (or excluded from) the response.
+
+Grape entity can track the path of each attribute, then you could access it during condition check
+or runtime exposure, via `options[:attr_path]`.
+
+Attribute path is an array. The last item of this array is the name (alias) of current attribute.
+And if the attribute is nested, the former items are names (aliases) of its ancestor attributes.
+
+Here is an example shows what the attribute path will be.
+
+```ruby
+class Status < Grape::Entity
+  expose :user  # path is [:user]
+  expose :foo, as: :bar  # path is [:bar]
+  expose :a do
+    expose :b, as: :xx do
+      expose :c  # path is [:a, :xx, :c]
+    end
+  end
+end
+```
+
 ### Using the Exposure DSL
 
 Grape ships with a DSL to easily define entities within the context of an existing class:


### PR DESCRIPTION
Make Grape::Entity keep tracking of current being exposed attribute's full path into `options[:attr_path]`.