### PR TITLE
Rewrite array methods delegation to @exposures.

### DIFF
--- a/lib/grape_entity/exposure/nesting_exposure/nested_exposures.rb
+++ b/lib/grape_entity/exposure/nesting_exposure/nested_exposures.rb
@@ -28,15 +28,25 @@ module Grape
             @exposures.clear
           end
 
-          delegate :each,
-                   :to_ary, :to_a,
-                   :[],
-                   :==,
-                   :size,
-                   :count,
-                   :length,
-                   :empty?,
-                   to: :@exposures
+          [
+            :each,
+            :to_ary, :to_a,
+            :all?,
+            :select,
+            :each_with_object,
+            :[],
+            :==,
+            :size,
+            :count,
+            :length,
+            :empty?
+          ].each do |name|
+            class_eval <<-RUBY, __FILE__, __LINE__
+              def #{name}(*args, &block)
+                @exposures.#{name}(*args, &block)
+              end
+            RUBY
+          end
 
           # Determine if we have any nesting exposures with the same name.
           def deep_complex_nesting?


### PR DESCRIPTION
ActiveSupport's `delegate` adds an overhead that we simply don't need.
And it's easy to implement efficient delegation for this specific task.
This patch also adds new methods for delegation: `select`, `all?` and
`each_with_object` that are heavily used internally.

It's a micro-optimization but it's easy to implement so here it is.