### PR TITLE
Fix: entity instance methods exposure (0.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.7 (2015-08-03)
+==================
+* [#164](https://github.com/intridea/grape-entity/pull/164): Regression: entity instance methods were exposed with `NoMethodError`: [#163](https://github.com/intridea/grape-entity/issues/163) - [@marshall-lee](http://github.com/marshall-lee).
+
 0.4.6 (2015-07-27)
 ==================
 

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -589,10 +589,11 @@ module Grape
         true
       else
         name = self.class.name_for(attribute)
+        is_delegatable = delegator.delegatable?(name) || respond_to?(name, true)
         if exposure_options[:safe]
-          delegator.delegatable?(name)
+          is_delegatable
         else
-          delegator.delegatable?(name) || fail(NoMethodError, "#{self.class.name} missing attribute `#{name}' on #{object}")
+          is_delegatable || fail(NoMethodError, "#{self.class.name} missing attribute `#{name}' on #{object}")
         end
       end
     end

--- a/lib/grape_entity/version.rb
+++ b/lib/grape_entity/version.rb
@@ -1,3 +1,3 @@
 module GrapeEntity
-  VERSION = '0.4.6'
+  VERSION = '0.4.7'
 end

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -1198,6 +1198,10 @@ describe Grape::Entity do
         rep = EntitySpec::DelegatingEntity.new(friend)
         expect(rep.send(:value_for, :name)).to eq 'cooler name'
         expect(rep.send(:value_for, :email)).to eq 'joe@example.com'
+
+        another_friend = double('Friend', email: 'joe@example.com')
+        rep = EntitySpec::DelegatingEntity.new(another_friend)
+        expect(rep.send(:value_for, :name)).to eq 'cooler name'
       end
 
       context 'using' do


### PR DESCRIPTION
This one fixes a regression introduced in #147: entity instance methods
were exposed with `NoMethodError`.
Fixes #163. Additional specs are added.

Will be fixed in `0-4` and ported to `master`.